### PR TITLE
Min Reporting Stake

### DIFF
--- a/contracts/core/governance/Reporter.sol
+++ b/contracts/core/governance/Reporter.sol
@@ -37,7 +37,7 @@ abstract contract Reporter is IReporter, Witness {
     s.mustBeValidCover(key);
 
     uint256 incidentDate = block.timestamp; // solhint-disable-line
-    require(stake >= getMinStake(), "Stake insufficient");
+    require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, key, incidentDate);
 
@@ -69,7 +69,7 @@ abstract contract Reporter is IReporter, Witness {
     s.mustBeValidIncidentDate(key, incidentDate);
     s.mustBeDuringReportingPeriod(key);
 
-    require(stake >= getMinStake(), "Stake insufficient");
+    require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.addDispute(key, msg.sender, incidentDate, stake);
 
@@ -120,9 +120,5 @@ abstract contract Reporter is IReporter, Witness {
 
   function getResolutionDate(bytes32 key) external view override returns (uint256) {
     return s.getUintByKeys(ProtoUtilV1.NS_GOVERNANCE_RESOLUTION_TS, key);
-  }
-
-  function getMinStake() public view override returns (uint256) {
-    return s.getMinReportingStake();
   }
 }

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -53,6 +53,7 @@ interface ICover is IMember {
   function addCover(
     bytes32 key,
     bytes32 info,
+    uint256 minStakeToReport,
     uint256 reportingPeriod,
     uint256 stakeWithFee,
     address reassuranceToken,

--- a/contracts/interfaces/IReporter.sol
+++ b/contracts/interfaces/IReporter.sol
@@ -23,8 +23,6 @@ interface IReporter {
     uint256 stake
   ) external;
 
-  function getMinStake() external view returns (uint256);
-
   function getActiveIncidentDate(bytes32 key) external view returns (uint256);
 
   function getReporter(bytes32 key, uint256 incidentDate) external view returns (address);

--- a/contracts/libraries/GovernanceUtilV1.sol
+++ b/contracts/libraries/GovernanceUtilV1.sol
@@ -37,8 +37,8 @@ library GovernanceUtilV1 {
     return s.getUintByKey(ProtoUtilV1.NS_CLAIM_REPORTER_COMMISSION);
   }
 
-  function getMinReportingStake(IStore s) external view returns (uint256) {
-    return s.getUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE);
+  function getMinReportingStake(IStore s, bytes32 key) external view returns (uint256) {
+    return s.getUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE, key);
   }
 
   function getLatestIncidentDate(IStore s, bytes32 key) external view returns (uint256) {

--- a/docs/GovernanceUtilV1.md
+++ b/docs/GovernanceUtilV1.md
@@ -11,7 +11,7 @@ View Source: [contracts/libraries/GovernanceUtilV1.sol](../contracts/libraries/G
 - [getGovernanceReporterCommission(IStore s)](#getgovernancereportercommission)
 - [getClaimPlatformFee(IStore s)](#getclaimplatformfee)
 - [getClaimReporterCommission(IStore s)](#getclaimreportercommission)
-- [getMinReportingStake(IStore s)](#getminreportingstake)
+- [getMinReportingStake(IStore s, bytes32 key)](#getminreportingstake)
 - [getLatestIncidentDate(IStore s, bytes32 key)](#getlatestincidentdate)
 - [getResolutionTimestamp(IStore s, bytes32 key)](#getresolutiontimestamp)
 - [getReporter(IStore s, bytes32 key, uint256 incidentDate)](#getreporter)
@@ -146,7 +146,7 @@ function getClaimReporterCommission(IStore s) external view returns (uint256) {
 ### getMinReportingStake
 
 ```solidity
-function getMinReportingStake(IStore s) external view
+function getMinReportingStake(IStore s, bytes32 key) external view
 returns(uint256)
 ```
 
@@ -155,13 +155,14 @@ returns(uint256)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | s | IStore |  | 
+| key | bytes32 |  | 
 
 <details>
 	<summary><strong>Source Code</strong></summary>
 
 ```javascript
-function getMinReportingStake(IStore s) external view returns (uint256) {
-    return s.getUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE);
+function getMinReportingStake(IStore s, bytes32 key) external view returns (uint256) {
+    return s.getUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE, key);
   }
 ```
 </details>

--- a/docs/ICover.md
+++ b/docs/ICover.md
@@ -21,7 +21,7 @@ event CoverInitialized(address indexed stablecoin, bytes32  withName);
 ## Functions
 
 - [initialize(address liquidityToken, bytes32 liquidityName)](#initialize)
-- [addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity)](#addcover)
+- [addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity)](#addcover)
 - [updateCover(bytes32 key, bytes32 info)](#updatecover)
 - [updateWhitelist(address account, bool whitelisted)](#updatewhitelist)
 - [getCover(bytes32 key)](#getcover)
@@ -67,7 +67,7 @@ Adds a new coverage pool or cover contract.
  https://docs.neptunemutual.com/covers/contract-creators
 
 ```solidity
-function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity) external nonpayable
+function addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity) external nonpayable
 ```
 
 **Arguments**
@@ -76,6 +76,7 @@ function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 st
 | ------------- |------------- | -----|
 | key | bytes32 | Enter a unique key for this cover | 
 | info | bytes32 | IPFS info of the cover contract | 
+| minStakeToReport | uint256 |  | 
 | reportingPeriod | uint256 | The period during when reporting happens. | 
 | stakeWithFee | uint256 | Enter the total NPM amount (stake + fee) to transfer to this contract. | 
 | reassuranceToken | address | **Optional.** Token added as an reassurance of this cover. <br /><br />  Reassurance tokens can be added by a project to demonstrate coverage support  for their own project. This helps bring the cover fee down and enhances  liquidity provider confidence. Along with the NPM tokens, the reassurance tokens are rewarded  as a support to the liquidity providers when a cover incident occurs. | 
@@ -89,6 +90,7 @@ function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 st
 function addCover(
     bytes32 key,
     bytes32 info,
+    uint256 minStakeToReport,
     uint256 reportingPeriod,
     uint256 stakeWithFee,
     address reassuranceToken,

--- a/docs/IReporter.md
+++ b/docs/IReporter.md
@@ -20,7 +20,6 @@ event ReporterCommissionSet(uint256  previous, uint256  current);
 
 - [report(bytes32 key, bytes32 info, uint256 stake)](#report)
 - [dispute(bytes32 key, uint256 incidentDate, bytes32 info, uint256 stake)](#dispute)
-- [getMinStake()](#getminstake)
 - [getActiveIncidentDate(bytes32 key)](#getactiveincidentdate)
 - [getReporter(bytes32 key, uint256 incidentDate)](#getreporter)
 - [getResolutionDate(bytes32 key)](#getresolutiondate)
@@ -79,26 +78,6 @@ function dispute(
     bytes32 info,
     uint256 stake
   ) external;
-```
-</details>
-
-### getMinStake
-
-```solidity
-function getMinStake() external view
-returns(uint256)
-```
-
-**Arguments**
-
-| Name        | Type           | Description  |
-| ------------- |------------- | -----|
-
-<details>
-	<summary><strong>Source Code</strong></summary>
-
-```javascript
-function getMinStake() external view returns (uint256);
 ```
 </details>
 

--- a/docs/Reporter.md
+++ b/docs/Reporter.md
@@ -26,7 +26,6 @@ This contract enables any NPM tokenholder to
 - [getActiveIncidentDate(bytes32 key)](#getactiveincidentdate)
 - [getReporter(bytes32 key, uint256 incidentDate)](#getreporter)
 - [getResolutionDate(bytes32 key)](#getresolutiondate)
-- [getMinStake()](#getminstake)
 
 ### report
 
@@ -57,7 +56,7 @@ function report(
     s.mustBeValidCover(key);
 
     uint256 incidentDate = block.timestamp; // solhint-disable-line
-    require(stake >= getMinStake(), "Stake insufficient");
+    require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, key, incidentDate);
 
@@ -110,7 +109,7 @@ function dispute(
     s.mustBeValidIncidentDate(key, incidentDate);
     s.mustBeDuringReportingPeriod(key);
 
-    require(stake >= getMinStake(), "Stake insufficient");
+    require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.addDispute(key, msg.sender, incidentDate, stake);
 
@@ -273,28 +272,6 @@ returns(uint256)
 ```javascript
 function getResolutionDate(bytes32 key) external view override returns (uint256) {
     return s.getUintByKeys(ProtoUtilV1.NS_GOVERNANCE_RESOLUTION_TS, key);
-  }
-```
-</details>
-
-### getMinStake
-
-```solidity
-function getMinStake() public view
-returns(uint256)
-```
-
-**Arguments**
-
-| Name        | Type           | Description  |
-| ------------- |------------- | -----|
-
-<details>
-	<summary><strong>Source Code</strong></summary>
-
-```javascript
-function getMinStake() public view override returns (uint256) {
-    return s.getMinReportingStake();
   }
 ```
 </details>

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,8 @@ The cover contract facilitates you create and update covers
 
 - [constructor(IStore store)](#)
 - [updateCover(bytes32 key, bytes32 info)](#updatecover)
-- [addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity)](#addcover)
-- [_addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 fee, address reassuranceToken)](#_addcover)
+- [addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity)](#addcover)
+- [_addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 fee, address reassuranceToken)](#_addcover)
 - [_validateAndGetFee(bytes32 key, bytes32 info, uint256 stakeWithFee)](#_validateandgetfee)
 - [updateWhitelist(address account, bool status)](#updatewhitelist)
 - [checkIfWhitelisted(address account)](#checkifwhitelisted)
@@ -100,7 +100,7 @@ Adds a new coverage pool or cover contract.
  https://docs.neptunemutual.com/covers/contract-creators
 
 ```solidity
-function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity) external nonpayable nonReentrant 
+function addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 stakeWithFee, address reassuranceToken, uint256 initialReassuranceAmount, uint256 initialLiquidity) external nonpayable nonReentrant 
 ```
 
 **Arguments**
@@ -109,6 +109,7 @@ function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 st
 | ------------- |------------- | -----|
 | key | bytes32 | Enter a unique key for this cover | 
 | info | bytes32 | IPFS info of the cover contract | 
+| minStakeToReport | uint256 | A cover creator can override default min NPM stake to avoid spam reports | 
 | reportingPeriod | uint256 | The period during when reporting happens. | 
 | stakeWithFee | uint256 | Enter the total NPM amount (stake + fee) to transfer to this contract. | 
 | reassuranceToken | address | **Optional.** Token added as an reassurance of this cover. <br /><br />  Reassurance tokens can be added by a project to demonstrate coverage support  for their own project. This helps bring the cover fee down and enhances  liquidity provider confidence. Along with the NPM tokens, the reassurance tokens are rewarded  as a support to the liquidity providers when a cover incident occurs. | 
@@ -122,6 +123,7 @@ function addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 st
 function addCover(
     bytes32 key,
     bytes32 info,
+    uint256 minStakeToReport,
     uint256 reportingPeriod,
     uint256 stakeWithFee,
     address reassuranceToken,
@@ -133,6 +135,7 @@ function addCover(
     s.mustNotBePaused();
     s.senderMustBeWhitelisted();
 
+    require(minStakeToReport >= s.getUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE), "Min NPM stake too low");
     require(reassuranceToken == s.getStablecoin(), "Invalid reassurance token");
     require(reportingPeriod >= 7 days, "Insufficient reporting period");
 
@@ -140,7 +143,7 @@ function addCover(
     uint256 fee = _validateAndGetFee(key, info, stakeWithFee);
 
     // Set the basic cover info
-    _addCover(key, info, reportingPeriod, fee, reassuranceToken);
+    _addCover(key, info, minStakeToReport, reportingPeriod, fee, reassuranceToken);
 
     // Stake the supplied NPM tokens and burn the fees
     s.getStakingContract().increaseStake(key, msg.sender, stakeWithFee, fee);
@@ -168,7 +171,7 @@ function addCover(
 ### _addCover
 
 ```solidity
-function _addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 fee, address reassuranceToken) private nonpayable
+function _addCover(bytes32 key, bytes32 info, uint256 minStakeToReport, uint256 reportingPeriod, uint256 fee, address reassuranceToken) private nonpayable
 ```
 
 **Arguments**
@@ -177,6 +180,7 @@ function _addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 f
 | ------------- |------------- | -----|
 | key | bytes32 | Enter a unique key for this cover | 
 | info | bytes32 | IPFS info of the cover contract | 
+| minStakeToReport | uint256 |  | 
 | reportingPeriod | uint256 | The period during when reporting happens. | 
 | fee | uint256 | Fee paid to create this cover | 
 | reassuranceToken | address | **Optional.** Token added as an reassurance of this cover. | 
@@ -188,6 +192,7 @@ function _addCover(bytes32 key, bytes32 info, uint256 reportingPeriod, uint256 f
 function _addCover(
     bytes32 key,
     bytes32 info,
+    uint256 minStakeToReport,
     uint256 reportingPeriod,
     uint256 fee,
     address reassuranceToken
@@ -201,6 +206,7 @@ function _addCover(
     // Set cover info
     s.setBytes32ByKeys(ProtoUtilV1.NS_COVER_INFO, key, info);
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_PERIOD, key, reportingPeriod);
+    s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE, key, minStakeToReport);
 
     // Set reassurance token
     s.setAddressByKeys(ProtoUtilV1.NS_COVER_REASSURANCE_TOKEN, key, reassuranceToken);

--- a/stories/0. setup.story.js
+++ b/stories/0. setup.story.js
@@ -81,6 +81,7 @@ describe('Protocol Initialization Stories', () => {
     const stakeWithFee = helper.ether(10000)
     const initialReassuranceAmount = helper.ether(1000000)
     const initialLiquidity = helper.ether(4000000)
+    const minReportingStake = helper.ether(250)
     const reportingPeriod = 7 * DAYS
 
     await contracts.npm.approve(contracts.stakingContract.address, stakeWithFee)
@@ -95,7 +96,7 @@ describe('Protocol Initialization Stories', () => {
       reassuranceTokenBalance: (await contracts.reassuranceToken.balanceOf(reassuranceVault)).toString()
     }
 
-    await contracts.cover.addCover(coverKey, info, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
+    await contracts.cover.addCover(coverKey, info, minReportingStake, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
   })
 
   it('corretness rule: xDai should\'ve been correctly added to the vault', async () => {

--- a/stories/1. policy.story.js
+++ b/stories/1. policy.story.js
@@ -31,13 +31,14 @@ describe('Policy Purchase Stories', () => {
     const stakeWithFee = helper.ether(10_000)
     const initialReassuranceAmount = helper.ether(1_000_000)
     const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
     const reportingPeriod = 7 * DAYS
 
     await contracts.npm.approve(contracts.stakingContract.address, stakeWithFee)
     await contracts.reassuranceToken.approve(contracts.reassuranceContract.address, initialReassuranceAmount)
     await contracts.wxDai.approve(contracts.cover.address, initialLiquidity)
 
-    await contracts.cover.addCover(coverKey, info, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
+    await contracts.cover.addCover(coverKey, info, minReportingStake, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
   })
 
   it('provision of 1M NPM tokens was added to the `Compound Finance Cover` pool', async () => {

--- a/stories/2. governance.story.js
+++ b/stories/2. governance.story.js
@@ -78,6 +78,7 @@ describe('Governance Stories', () => {
     const stakeWithFee = helper.ether(10_000)
     const initialReassuranceAmount = helper.ether(1_000_000)
     const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
     const reportingPeriod = 7 * constants.DAYS
 
     // Submit approvals
@@ -86,7 +87,7 @@ describe('Governance Stories', () => {
     await contracts.wxDai.approve(contracts.cover.address, initialLiquidity)
 
     // Create a new cover
-    await contracts.cover.addCover(coverKey, info, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
+    await contracts.cover.addCover(coverKey, info, minReportingStake, reportingPeriod, stakeWithFee, contracts.reassuranceToken.address, initialReassuranceAmount, initialLiquidity)
 
     // Add provision
     const provision = helper.ether(1_000_001)


### PR DESCRIPTION
To avoid spam report, enabled Cover Creators to override minimum stake required to submit the first incident report.