### PR TITLE
Unit Test Setup

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,3 @@
+module.exports = {
+  skipFiles: ['contracts/mock/**/*.sol']
+}

--- a/contracts/core/lifecycle/CoverReassurance.sol
+++ b/contracts/core/lifecycle/CoverReassurance.sol
@@ -41,8 +41,10 @@ contract CoverReassurance is ICoverReassurance, Recoverable {
     address account,
     uint256 amount
   ) external override nonReentrant {
+    // @suppress-acl Reassurance can only be added by cover owner or latest cover contract
     s.mustNotBePaused();
     s.mustBeValidCoverKey(key);
+    s.mustBeCoverOwnerOrCoverContract(key, msg.sender);
 
     require(amount > 0, "Provide valid amount");
 

--- a/contracts/libraries/RegistryLibV1.sol
+++ b/contracts/libraries/RegistryLibV1.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.0;
 
 import "./ProtoUtilV1.sol";
 import "./StoreKeyUtil.sol";
+import "../interfaces/ICover.sol";
 import "../interfaces/IPolicy.sol";
 import "../interfaces/IBondPool.sol";
 import "../interfaces/ICoverStake.sol";
@@ -48,6 +49,11 @@ library RegistryLibV1 {
 
   function getBondPoolContract(IStore s) external view returns (IBondPool) {
     return IBondPool(s.getContract(ProtoUtilV1.CNS_POOL_BOND));
+  }
+
+  function getCoverContract(IStore s) external view returns (ICover) {
+    address vault = s.getAddressByKeys(ProtoUtilV1.NS_CONTRACTS, ProtoUtilV1.CNS_COVER);
+    return ICover(vault);
   }
 
   function getVault(IStore s, bytes32 key) external view returns (IVault) {

--- a/contracts/mock/base/MockCxToken.sol
+++ b/contracts/mock/base/MockCxToken.sol
@@ -1,0 +1,22 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract MockCxToken is ERC20 {
+  constructor() ERC20("Test", "Test") {
+    super._mint(msg.sender, 1 ether);
+  }
+
+  function burn(uint256 amount) external {
+    super._burn(msg.sender, amount);
+  }
+
+  function expiresOn() external view returns (uint256) {
+    return block.timestamp + 30 days; // solhint-disable-line
+  }
+
+  function coverKey() external pure returns (bytes32) {
+    return "test";
+  }
+}

--- a/contracts/mock/base/MockProtocol.sol
+++ b/contracts/mock/base/MockProtocol.sol
@@ -1,0 +1,28 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "openzeppelin-solidity/contracts/access/AccessControl.sol";
+
+contract MockProtocol is AccessControl {
+  bool public _state = false;
+
+  function setPaused(bool state) public {
+    _state = state;
+  }
+
+  function paused() public view returns (bool) {
+    return _state;
+  }
+
+  function setupRole(
+    bytes32 role,
+    bytes32 adminRole,
+    address account
+  ) external {
+    _setRoleAdmin(role, adminRole);
+
+    if (account != address(0)) {
+      _setupRole(role, account);
+    }
+  }
+}

--- a/contracts/mock/base/MockStore.sol
+++ b/contracts/mock/base/MockStore.sol
@@ -1,0 +1,41 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "../../fakes/FakeStore.sol";
+
+contract MockStore is FakeStore {
+  function setBool(bytes32 prefix, address a) public {
+    bytes32 k = keccak256(abi.encodePacked(prefix, a));
+    this.setBool(k, true);
+  }
+
+  function unsetBool(bytes32 prefix, address a) public {
+    bytes32 k = keccak256(abi.encodePacked(prefix, a));
+    this.deleteBool(k);
+  }
+
+  function setAddress(
+    bytes32 k1,
+    bytes32 k2,
+    address v
+  ) public {
+    this.setAddress(keccak256(abi.encodePacked(k1, k2)), v);
+  }
+
+  function setAddress(
+    bytes32 k1,
+    bytes32 k2,
+    bytes32 k3,
+    address v
+  ) public {
+    this.setAddress(keccak256(abi.encodePacked(k1, k2, k3)), v);
+  }
+
+  function setUint(
+    bytes32 k1,
+    bytes32 k2,
+    uint256 v
+  ) public {
+    this.setUint(keccak256(abi.encodePacked(k1, k2)), v);
+  }
+}

--- a/contracts/mock/claims-processor/MockProcessorStore.sol
+++ b/contracts/mock/claims-processor/MockProcessorStore.sol
@@ -1,0 +1,48 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "../base/MockStore.sol";
+import "../base/MockProtocol.sol";
+import "./MockVault.sol";
+import "../../libraries/ProtoUtilV1.sol";
+
+contract MockProcessorStore is MockStore {
+  function initialize(bytes32 key, address cxToken) public returns (address[] memory values) {
+    MockProtocol protocol = new MockProtocol();
+    MockVault vault = new MockVault();
+
+    this.setAddress(ProtoUtilV1.CNS_CORE, address(protocol));
+
+    super.setBool(ProtoUtilV1.NS_COVER_CXTOKEN, cxToken);
+    super.setBool(ProtoUtilV1.NS_MEMBERS, cxToken);
+    super.setUint(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, key, 1234);
+
+    super.setBool(ProtoUtilV1.NS_MEMBERS, address(vault));
+    super.setAddress(ProtoUtilV1.NS_CONTRACTS, "cns:cover:vault", key, address(vault));
+
+    setCoverStatus(key, 4);
+    setClaimBeginTimestamp(key, block.timestamp - 100 days); // solhint-disable-line
+    setClaimExpiryTimestamp(key, block.timestamp + 100 days); // solhint-disable-line
+
+    values = new address[](2);
+
+    values[0] = address(protocol);
+    values[1] = address(vault);
+  }
+
+  function disassociateCxToken(address cxToken) public {
+    super.unsetBool(ProtoUtilV1.NS_COVER_CXTOKEN, cxToken);
+  }
+
+  function setCoverStatus(bytes32 key, uint256 value) public {
+    super.setUint(ProtoUtilV1.NS_COVER_STATUS, key, value);
+  }
+
+  function setClaimBeginTimestamp(bytes32 key, uint256 value) public {
+    super.setUint(ProtoUtilV1.NS_CLAIM_BEGIN_TS, key, value);
+  }
+
+  function setClaimExpiryTimestamp(bytes32 key, uint256 value) public {
+    super.setUint(ProtoUtilV1.NS_CLAIM_EXPIRY_TS, key, value);
+  }
+}

--- a/contracts/mock/claims-processor/MockVault.sol
+++ b/contracts/mock/claims-processor/MockVault.sol
@@ -1,0 +1,20 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract MockVault is ERC20 {
+  constructor() ERC20("USD Coin", "USDC") {
+    super._mint(msg.sender, 100_000 ether);
+  }
+
+  function transferGovernance(
+    bytes32,
+    address sender,
+    uint256 amount
+  ) external {
+    if (sender != address(0)) {
+      super._mint(sender, amount);
+    }
+  }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -64,7 +64,7 @@ const config = {
     disambiguatePaths: false
   },
   etherscan: {
-    apiKey: process.env.BSCSCAN_API_KEY,
+    apiKey: process.env.ETHERSCAN_API_KEY,
     apiKeyAll: {
       mainnet: process.env.ETHERSCAN_API_KEY,
       ropsten: process.env.ETHERSCAN_API_KEY,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "slither:x:save": "slither . --print human-summary,vars-and-auth  > ./.todo/slither.x.log 2>&1",
     "test": "npx hardhat test",
     "test:all": "npx hardhat test ./**/*.{spec,story}.js",
+    "coverage": "npx hardhat coverage",
     "stories": "npx hardhat test ./**/*.story.js",
     "story": "yarn stories",
     "walk": "node ./util/analyzers/chain-state | sed -r \"s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g\" > ./.todo/_Walker.sol && echo View file 👉 ./.todo/_Walker.sol"
@@ -60,11 +61,12 @@
     "hardhat-contract-sizer": "^2.1.1",
     "hardhat-gas-reporter": "^1.0.6",
     "ipfs-mini": "^1.1.5",
+    "moment": "^2.29.1",
     "openzeppelin-solidity": "^4.4.1",
     "prettier": "^2.5.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solhint": "^3.3.6",
-    "solidity-coverage": "^0.7.16",
+    "solidity-coverage": "^0.7.17",
     "solidoc2": "^1.0.7",
     "standard": "^16.0.4"
   }

--- a/stories/1. policy.story.js
+++ b/stories/1. policy.story.js
@@ -47,7 +47,7 @@ describe('Policy Purchase Stories', () => {
 
     await contracts.npm.approve(contracts.provisionContract.address, provision)
 
-    await contracts.protocol.grantRole(key.toBytes32(key.NS.ROLES.LIQUIDITY_MANAGER), owner.address)
+    await contracts.protocol.grantRole(key.NS.ROLES.LIQUIDITY_MANAGER, owner.address)
     await contracts.provisionContract.increaseProvision(coverKey, provision)
 
     await contracts.provisionContract.decreaseProvision(coverKey, helper.ether(1))

--- a/stories/2. governance.story.js
+++ b/stories/2. governance.story.js
@@ -94,7 +94,7 @@ describe('Governance Stories', () => {
 
     await contracts.npm.approve(contracts.provisionContract.address, provision)
 
-    await contracts.protocol.grantRole(key.toBytes32(key.NS.ROLES.LIQUIDITY_MANAGER), _o.address)
+    await contracts.protocol.grantRole(key.NS.ROLES.LIQUIDITY_MANAGER, _o.address)
     await contracts.provisionContract.increaseProvision(coverKey, provision)
 
     // Purchase a cover
@@ -346,8 +346,8 @@ describe('Governance Stories', () => {
   it('a governance agent resolves the cover', async () => {
     const [_o, _a] = await ethers.getSigners() // eslint-disable-line
 
-    await contracts.protocol.grantRole(key.toBytes32(key.NS.ROLES.GOVERNANCE_ADMIN), _o.address)
-    await contracts.protocol.grantRole(key.toBytes32(key.NS.ROLES.GOVERNANCE_AGENT), _a.address)
+    await contracts.protocol.grantRole(key.NS.ROLES.GOVERNANCE_ADMIN, _o.address)
+    await contracts.protocol.grantRole(key.NS.ROLES.GOVERNANCE_AGENT, _a.address)
 
     const incidentDate = await contracts.governance.getActiveIncidentDate(coverKey)
 

--- a/test/claims-processor/claim.spec.js
+++ b/test/claims-processor/claim.spec.js
@@ -1,0 +1,56 @@
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../util')
+const { deployDependencies } = require('./deps')
+
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Claims Processor: `claim` function', () => {
+  let libraries, store, cxToken, processor
+
+  beforeEach(async () => {
+    libraries = await deployDependencies()
+
+    store = await deployer.deploy(cache, 'MockProcessorStore')
+    cxToken = await deployer.deploy(cache, 'MockCxToken')
+    processor = await deployer.deployWithLibraries(cache, 'Processor', libraries.dependencies, store.address)
+  })
+
+  it('must succeed if all conditions are met', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+    await cxToken.approve(processor.address, '1')
+
+    await processor.claim(cxToken.address, coverKey, incidentDate, '1')
+  })
+
+  it('must correctly emit `Claimed` event', async () => {
+    const [owner] = await ethers.getSigners()
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+    const amount = '1'
+
+    await store.initialize(coverKey, cxToken.address)
+    await cxToken.approve(processor.address, '1')
+
+    const tx = await processor.claim(cxToken.address, coverKey, incidentDate, amount)
+    const { events } = await tx.wait()
+    const event = events.pop()
+
+    event.event.should.equal('Claimed')
+    event.args.cxToken.should.equal(cxToken.address)
+    event.args.key.should.equal(coverKey)
+    event.args.account.should.equal(owner.address)
+    event.args.reporter.should.equal(helper.zerox)
+    event.args.amount.should.equal(amount)
+    event.args.reporterFee.should.equal('0')
+    event.args.platformFee.should.equal('0')
+    event.args.claimed.should.equal('1')
+  })
+})

--- a/test/claims-processor/ctor-vfns.spec.js
+++ b/test/claims-processor/ctor-vfns.spec.js
@@ -1,0 +1,57 @@
+const moment = require('moment')
+const BigNumber = require('bignumber.js')
+const { deployer, key } = require('../../util')
+const { deployDependencies } = require('./deps')
+
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Claims Processor: Constructor & Initializer', () => {
+  let libraries, store, processor
+
+  beforeEach(async () => {
+    libraries = await deployDependencies()
+    store = await deployer.deploy(cache, 'MockProcessorStore')
+    processor = await deployer.deployWithLibraries(cache, 'Processor', libraries.dependencies, store.address)
+  })
+
+  it('must successfully constructs the processor contract', async () => {
+    (await processor.s()).should.equal(store.address)
+  })
+
+  it('must ensure correct version number', async () => {
+    (await processor.version()).should.equal(key.toBytes32('v0.1'))
+  })
+
+  it('must ensure correct contract namespace', async () => {
+    (await processor.getName()).should.equal(key.CNAME_KEYS.PROCESSOR)
+  })
+})
+
+describe('Claims Processor: `getClaimExpiryDate` function', () => {
+  let libraries, cxToken, store, processor
+
+  beforeEach(async () => {
+    libraries = await deployDependencies()
+    cxToken = await deployer.deploy(cache, 'MockCxToken')
+    store = await deployer.deploy(cache, 'MockProcessorStore')
+    processor = await deployer.deployWithLibraries(cache, 'Processor', libraries.dependencies, store.address)
+  })
+
+  it('must correctly return the claim expiry date', async () => {
+    const startedOn = moment(new Date())
+
+    const coverKey = key.toBytes32('test')
+
+    await store.initialize(coverKey, cxToken.address)
+
+    const date = await processor.getClaimExpiryDate(coverKey)
+
+    date.should.be.gt(startedOn.add(100, 'd').unix())
+    date.should.be.lt(startedOn.add(101, 'd').unix())
+  })
+})

--- a/test/claims-processor/deps.js
+++ b/test/claims-processor/deps.js
@@ -1,0 +1,26 @@
+const composer = require('../../util/composer')
+const cache = null
+
+/**
+ * Deploys all libraries
+ * @return {Promise<{dependencies: Object, all: Libraries}>}
+ */
+const deployDependencies = async () => {
+  const libs = await composer.libs.deployAll(cache)
+
+  return {
+    dependencies: {
+      BaseLibV1: libs.baseLibV1.address,
+      NTransferUtilV2: libs.transferLib.address,
+      RegistryLibV1: libs.registryLib.address,
+      StoreKeyUtil: libs.storeKeyUtil.address,
+      ValidationLibV1: libs.validationLib.address,
+      AccessControlLibV1: libs.accessControlLibV1.address,
+      GovernanceUtilV1: libs.governanceLib.address,
+      ProtoUtilV1: libs.protoUtilV1.address
+    },
+    all: libs
+  }
+}
+
+module.exports = { deployDependencies }

--- a/test/claims-processor/set-claim-period.spec.js
+++ b/test/claims-processor/set-claim-period.spec.js
@@ -1,0 +1,71 @@
+const moment = require('moment')
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../util')
+const { deployDependencies } = require('./deps')
+const attacher = require('../util/attach')
+const DAYS = 86400
+
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Claims Processor: `setClaimPeriod` function', () => {
+  let libraries, store, cxToken, processor
+
+  beforeEach(async () => {
+    libraries = await deployDependencies()
+
+    store = await deployer.deploy(cache, 'MockProcessorStore')
+    cxToken = await deployer.deploy(cache, 'MockCxToken')
+    processor = await deployer.deployWithLibraries(cache, 'Processor', libraries.dependencies, store.address)
+  })
+
+  it('must succeed if all conditions are met', async () => {
+    const [owner] = await ethers.getSigners()
+    const newClaimPeriod = 7 * DAYS
+    const coverKey = key.toBytes32('test')
+
+    const [protocolAddress] = await store.callStatic.initialize(coverKey, cxToken.address)
+    await store.initialize(coverKey, cxToken.address)
+
+    const protocol = await attacher.protocol.attach(protocolAddress, libraries.all)
+
+    await protocol.setupRole(key.NS.ROLES.ADMIN, key.NS.ROLES.ADMIN, owner.address)
+    await protocol.setupRole(key.NS.ROLES.COVER_MANAGER, key.NS.ROLES.ADMIN, owner.address)
+
+    const tx = await processor.setClaimPeriod(newClaimPeriod)
+    const { events } = await tx.wait()
+    const [event] = events
+
+    events.length.should.equal(1)
+
+    event.event.should.equal('ClaimPeriodSet')
+    event.args.previous.should.equal('0')
+    event.args.current.should.equal(newClaimPeriod)
+  })
+
+  it('must reject if the protocol is paused', async () => {
+    const newClaimPeriod = 7 * DAYS
+    const coverKey = key.toBytes32('test')
+
+    const [protocolAddress] = await store.callStatic.initialize(coverKey, cxToken.address)
+    await store.initialize(coverKey, cxToken.address)
+
+    const protocol = await attacher.protocol.attach(protocolAddress, libraries.all)
+
+    await protocol.setPaused(true)
+
+    await processor.setClaimPeriod(newClaimPeriod).should.be.revertedWith('Protocol is paused')
+  })
+
+  it('must reject if accessed by anyone else but cover manager', async () => {
+    const newClaimPeriod = 7 * DAYS
+    const coverKey = key.toBytes32('test')
+
+    await store.initialize(coverKey, cxToken.address)
+    await processor.setClaimPeriod(newClaimPeriod).should.be.revertedWith('Forbidden')
+  })
+})

--- a/test/claims-processor/validate.spec.js
+++ b/test/claims-processor/validate.spec.js
@@ -1,0 +1,163 @@
+const moment = require('moment')
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../util')
+const { deployDependencies } = require('./deps')
+const attacher = require('../util/attach')
+
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Claims Processor: `validate` function', () => {
+  let libraries, store, cxToken, processor
+
+  beforeEach(async () => {
+    libraries = await deployDependencies()
+
+    store = await deployer.deploy(cache, 'MockProcessorStore')
+    cxToken = await deployer.deploy(cache, 'MockCxToken')
+    processor = await deployer.deployWithLibraries(cache, 'Processor', libraries.dependencies, store.address)
+  })
+
+  it('must succeed if all conditions are met', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+    await cxToken.approve(processor.address, '1')
+
+    await processor.validate(cxToken.address, coverKey, incidentDate)
+  })
+
+  it('must reject if the protocol is paused', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    const [protocolAddress] = await store.callStatic.initialize(coverKey, cxToken.address)
+    await store.initialize(coverKey, cxToken.address)
+
+    const protocol = await attacher.protocol.attach(protocolAddress, libraries.all)
+    await protocol.setPaused(true)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Protocol is paused')
+    await protocol.setPaused(false)
+  })
+
+  it('must reject if the cxToken is not a protocol member', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, helper.zerox)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Not a protocol member')
+  })
+
+  it('must reject if the cxToken is not associated with the given cover key', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+    await store.disassociateCxToken(cxToken.address)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Unknown cxToken')
+  })
+
+  it('must reject if the cxToken key does not match with the given cover key', async () => {
+    const coverKey = key.toBytes32('invalid-key')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Invalid cxToken')
+  })
+
+  it('must reject if the cxToken has already expired', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = moment('2055-01-01') // very far into the future
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate.unix()).should.be.revertedWith('Invalid or expired cxToken')
+  })
+
+  it('must reject if the cover is not resolved, i.e. claimable', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+    await store.setCoverStatus(coverKey, 1)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Not claimable')
+  })
+
+  it('must reject if incident date is invalid', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '12345'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Invalid incident date')
+  })
+
+  it('must reject if there is no claim begin date set', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await store.setClaimBeginTimestamp(coverKey, '0')
+    await store.setClaimExpiryTimestamp(coverKey, moment('2030-01-02').unix())
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Invalid claim begin date')
+  })
+
+  it('must reject if claim expiry date is greater than claim begin date', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await store.setClaimBeginTimestamp(coverKey, moment('2030-02-01').unix())
+    await store.setClaimExpiryTimestamp(coverKey, moment('2030-01-01').unix())
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Invalid claim period')
+  })
+
+  it('must reject if claim period has not begun', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await store.setClaimBeginTimestamp(coverKey, moment('2030-01-01').unix())
+    await store.setClaimExpiryTimestamp(coverKey, moment('2030-01-02').unix())
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Claim period hasn\'t begun')
+  })
+
+  it('must reject if claim period is over or expired', async () => {
+    const coverKey = key.toBytes32('test')
+    const incidentDate = '1234'
+
+    await store.initialize(coverKey, cxToken.address)
+
+    await store.setClaimBeginTimestamp(coverKey, moment('2010-01-01').unix())
+    await store.setClaimExpiryTimestamp(coverKey, moment('2010-01-02').unix())
+
+    await cxToken.approve(processor.address, '1')
+    await processor.validate(cxToken.address, coverKey, incidentDate).should.be.revertedWith('Claim period has expired')
+  })
+})

--- a/test/protocol.spec.js
+++ b/test/protocol.spec.js
@@ -47,7 +47,8 @@ const deployDependencies = async () => {
     ProtoUtilV1: protoUtilV1.address,
     StoreKeyUtil: storeKeyUtil.address,
     CoverUtilV1: coverUtilV1.address,
-    GovernanceUtilV1: governanceUtilV1.address
+    GovernanceUtilV1: governanceUtilV1.address,
+    RegistryLibV1: registryLibV1.address
   })
 
   const baseLibV1 = await deployer.deployWithLibraries(cache, 'BaseLibV1', {
@@ -316,7 +317,7 @@ describe('Adding a New Protocol Contract', () => {
       store.address
     )
 
-    await protocol.grantRole(key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
+    await protocol.grantRole(key.NS.ROLES.UPGRADE_AGENT, owner.address)
 
     await store.setBool(key.qualify(protocol.address), true)
     await store.setBool(key.qualifyMember(protocol.address), true)
@@ -385,7 +386,7 @@ describe('Upgrading Protocol Contract(s)', () => {
     await store.setBool(key.qualify(protocol.address), true)
     await store.setBool(key.qualifyMember(protocol.address), true)
 
-    await protocol.grantRole(key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
+    await protocol.grantRole(key.NS.ROLES.UPGRADE_AGENT, owner.address)
 
     await protocol.initialize(
       [helper.zero1,
@@ -471,8 +472,8 @@ describe('Adding a New Protocol Member', () => {
     await store.setBool(key.qualify(protocol.address), true)
     await store.setBool(key.qualifyMember(protocol.address), true)
 
-    await protocol.grantRole(key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
-    await protocol.grantRole(key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
+    await protocol.grantRole(key.NS.ROLES.UPGRADE_AGENT, owner.address)
+    await protocol.grantRole(key.NS.ROLES.UPGRADE_AGENT, owner.address)
 
     await protocol.initialize(
       [helper.zero1,
@@ -543,7 +544,7 @@ describe('Removing Protocol Member(s)', () => {
     await store.setBool(key.qualify(protocol.address), true)
     await store.setBool(key.qualifyMember(protocol.address), true)
 
-    await protocol.grantRole(key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
+    await protocol.grantRole(key.NS.ROLES.UPGRADE_AGENT, owner.address)
 
     await protocol.initialize(
       [helper.zero1,

--- a/test/util/attach/attach.js
+++ b/test/util/attach/attach.js
@@ -1,0 +1,8 @@
+const { ethers } = require('hardhat')
+
+const attach = async (contractName, address, libraries) => {
+  const contract = libraries ? await ethers.getContractFactory(contractName, libraries) : await ethers.getContractFactory(contractName)
+  return contract.attach(address)
+}
+
+module.exports = { attach }

--- a/test/util/attach/index.js
+++ b/test/util/attach/index.js
@@ -1,0 +1,4 @@
+const attach = require('./attach')
+const protocol = require('./protocol')
+
+module.exports = { attach, protocol }

--- a/test/util/attach/protocol.js
+++ b/test/util/attach/protocol.js
@@ -1,0 +1,19 @@
+const { attach } = require('./attach')
+
+/**
+ * Attaches protocol instance to a given address
+ * @param {string} address
+ * @param {Libraries} libraries
+ * @returns {ethers.Contract}
+ */
+const doit = async (address, libraries) => {
+  return attach('MockProtocol', address, {
+    AccessControlLibV1: libraries.accessControlLibV1.address,
+    BaseLibV1: libraries.baseLibV1.address,
+    ProtoUtilV1: libraries.protoUtilV1.address,
+    StoreKeyUtil: libraries.storeKeyUtil.address,
+    ValidationLibV1: libraries.validationLib.address
+  })
+}
+
+module.exports = { attach: doit }

--- a/util/composer/initializer.js
+++ b/util/composer/initializer.js
@@ -49,7 +49,7 @@ const initialize = async (suite, deploymentId) => {
   await intermediate(cache, store, 'setBool', key.qualify(protocol.address), true)
   await intermediate(cache, store, 'setBool', key.qualifyMember(protocol.address), true)
 
-  await intermediate(cache, protocol, 'grantRole', key.toBytes32(key.NS.ROLES.UPGRADE_AGENT), owner.address)
+  await intermediate(cache, protocol, 'grantRole', key.NS.ROLES.UPGRADE_AGENT, owner.address)
 
   await intermediate(cache, protocol, 'initialize',
     [helper.zero1,
@@ -217,7 +217,7 @@ const initialize = async (suite, deploymentId) => {
 
   await intermediate(cache, protocol, 'addContract', key.toBytes32(key.CNS.COVER_POLICY_ADMIN), policyAdminContract.address)
 
-  await intermediate(cache, protocol, 'grantRole', key.toBytes32(key.NS.ROLES.COVER_MANAGER), owner.address)
+  await intermediate(cache, protocol, 'grantRole', key.NS.ROLES.COVER_MANAGER, owner.address)
   await intermediate(cache, policyAdminContract, 'setPolicyRates', helper.ether(0.07), helper.ether(0.45))
   await intermediate(cache, cover, 'updateWhitelist', owner.address, true)
 

--- a/util/composer/libs.js
+++ b/util/composer/libs.js
@@ -40,7 +40,8 @@ const deployAll = async (cache) => {
     ProtoUtilV1: protoUtilV1.address,
     StoreKeyUtil: storeKeyUtil.address,
     CoverUtilV1: coverUtil.address,
-    GovernanceUtilV1: governanceLib.address
+    GovernanceUtilV1: governanceLib.address,
+    RegistryLibV1: registryLib.address
   })
 
   const vaultLib = await deployer.deployWithLibraries(cache, 'VaultLibV1', {

--- a/util/key.js
+++ b/util/key.js
@@ -57,20 +57,21 @@ const NS = {
   SETUP_FIRST_REPORTING_STAKE: 'ns:gov:1st:reporting:stake',
   SETUP_MIN_LIQ_PERIOD: 'ns:cover:liquidity:min:period',
   ROLES: {
-    ADMIN: 'role:admin',
-    COVER_MANAGER: 'role:cover:manager',
-    LIQUIDITY_MANAGER: 'role:liquidity:manager',
-    GOVERNANCE_ADMIN: 'role:governance:admin',
-    GOVERNANCE_AGENT: 'role:governance:agent',
-    UPGRADE_AGENT: 'role:upgrade:agent',
-    RECOVERY_AGENT: 'role:recovery:agent',
-    PAUSE_AGENT: 'role:pause:agent',
-    UNPAUSE_AGENT: 'role:unpause:agent'
+    ADMIN: toBytes32('role:admin'),
+    COVER_MANAGER: toBytes32('role:cover:manager'),
+    LIQUIDITY_MANAGER: toBytes32('role:liquidity:manager'),
+    GOVERNANCE_ADMIN: toBytes32('role:governance:admin'),
+    GOVERNANCE_AGENT: toBytes32('role:governance:agent'),
+    UPGRADE_AGENT: toBytes32('role:upgrade:agent'),
+    RECOVERY_AGENT: toBytes32('role:recovery:agent'),
+    PAUSE_AGENT: toBytes32('role:pause:agent'),
+    UNPAUSE_AGENT: toBytes32('role:unpause:agent')
   }
 }
 
 const CNAME = {
   PROTOCOL: 'Protocol',
+  PROCESSOR: 'ClaimsProcessor',
   TREASURY: 'Treasury',
   POLICY: 'Policy',
   PRICE_DISCOVERY: 'PriceDiscovery',
@@ -86,6 +87,7 @@ const CNAME = {
 // Note the protocol automatically prefixes these intermediate keys when adding
 const CNAME_KEYS = {
   PROTOCOL: toBytes32(CNAME.PROTOCOL),
+  PROCESSOR: toBytes32(CNAME.PROCESSOR),
   TREASURY: toBytes32(CNAME.TREASURY),
   POLICY: toBytes32(CNAME.POLICY),
   PRICE_DISCOVERY: toBytes32(CNAME.PRICE_DISCOVERY),
@@ -98,25 +100,11 @@ const CNAME_KEYS = {
   LIQUIDITY_VAULT: toBytes32(CNAME.LIQUIDITY_VAULT)
 }
 
-const CNAME_KEYS_FQN = {
-  PROTOCOL: qualifyBytes32(CNAME.PROTOCOL),
-  TREASURY: qualifyBytes32(CNAME.TREASURY),
-  POLICY: qualifyBytes32(CNAME.POLICY),
-  COVER: qualifyBytes32(CNAME.COVER),
-  VAULT_FACTORY: qualifyBytes32(CNAME.VAULT_FACTORY),
-  CXTOKEN_FACTORY: qualifyBytes32(CNAME.CXTOKEN_FACTORY),
-  COVER_PROVISION: qualifyBytes32(CNAME.COVER_PROVISION),
-  COVER_STAKE: qualifyBytes32(CNAME.COVER_STAKE),
-  COVER_REASSURANCE: qualifyBytes32(CNAME.COVER_REASSURANCE),
-  LIQUIDITY_VAULT: qualifyBytes32(CNAME.LIQUIDITY_VAULT)
-}
-
 module.exports = {
   NS,
   CNS,
   CNAME,
   CNAME_KEYS,
-  CNAME_KEYS_FQN,
   encodeKey,
   encodeKeys,
   toBytes32,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6571,6 +6571,11 @@ mock-fs@^4.1.0:
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
   integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 mri@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
@@ -8457,7 +8462,7 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
-solidity-coverage@^0.7.16:
+solidity-coverage@^0.7.17:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.17.tgz#5139de8f6666d4755d88f453d8e35632a7bb3444"
   integrity sha512-Erw2hd2xdACAvDX8jUdYkmgJlIIazGznwDJA5dhRaw4def2SisXN9jUjneeyOZnl/E7j6D3XJYug4Zg9iwodsg==


### PR DESCRIPTION
-Added unit test for the claims processor contract.
  - Added Mock Contracts
  - Added Unit Tests
- Refactored `addReassurance` on `CoverReassurance` contract to be accessible only to cover creators or the latest cover contract.
- Added `getCoverContract` on `RegistryLibV1`
- Added `mustBeCoverOwnerOrCoverContract` to `ValidationLibV1`
- More